### PR TITLE
Fix build on newer Rust versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(once_cell, thread_spawn_unchecked, exclusive_wrapper)]
+#![feature(once_cell, thread_spawn_unchecked, exclusive_wrapper, lazy_cell)]
 use std::{
     collections::HashMap,
     sync::atomic::{AtomicBool, Ordering},


### PR DESCRIPTION
It seems like at some point Rust started requiring the lazy_cell feature be enabled explicitly, so we do this now to make the build work.